### PR TITLE
Support for shipping address, dynamic quantity

### DIFF
--- a/wp-stripe-checkout/main.php
+++ b/wp-stripe-checkout/main.php
@@ -710,25 +710,32 @@ function wp_stripe_checkout_v3_button_handler($atts) {
     (function() {
         var stripe_$id = Stripe('$key');
         var checkoutButton_$id = document.querySelector('#wpsc$id');
-        checkoutButton_$id.addEventListener('click', function () {
-          stripe_$id.redirectToCheckout({
-            lineItems: [{
-              price: '{$identifier}',
-              quantity: parseInt(this.dataset.qty, 10)
-            }],
-            mode: 'payment',  
-            successUrl: '{$success_url}',
-            cancelUrl: '{$cancel_url}',
-            clientReferenceId: '$client_reference_id',
-            billingAddressCollection: 'required',
-            ${shipping_address}
-          })
-          .then(function (result) {
-              if (result.error) {
-                var displayError = document.getElementById('error-wpsc$id');
-                displayError.textContent = result.error.message;
-              }
-          });          
+        checkoutButton_$id.addEventListener('click', function() {
+            try {
+                stripe_$id.redirectToCheckout({
+                        lineItems: [{
+                            price: '{$identifier}',
+                            quantity: parseInt(this.dataset.qty, 10)
+                        }],
+                        mode: 'payment',
+                        successUrl: '{$success_url}',
+                        cancelUrl: '{$cancel_url}',
+                        clientReferenceId: '$client_reference_id',
+                        billingAddressCollection: 'required',
+                        ${shipping_address}
+                    })
+                    .then(function(result) {
+                        if (result.error) {
+                            var displayError = document.getElementById('error-wpsc$id');
+                            displayError.textContent = result.error.message;
+                        }
+                    });
+            } catch (error) {
+                if (error) {
+                    var displayError = document.getElementById('error-wpsc$id');
+                    displayError.textContent = error;
+                }
+            }
         });
     })();
     </script>        


### PR DESCRIPTION
- Add `shipping-countries` parameter. `shipping-countries` should be a comma-delimited list of allowed countries. This will enable a ship-to address on the checkout page.

> An array of two-letter ISO country codes representing which countries Checkout should provide as options for shipping locations. Unsupported country codes: AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI.

- Add `qty` parameter, which allows a quantity > 1. Also, this can be updated dynamically by the user, e.g.

```js
$('button.stripe').attr('data-qty', 14); // this would update qty to 14
```