### PR TITLE
Support for Text Custom Fields in Payment Links

### DIFF
--- a/wp-stripe-checkout/wp-stripe-checkout-process-webhook.php
+++ b/wp-stripe-checkout/wp-stripe-checkout-process-webhook.php
@@ -91,9 +91,10 @@ function wp_stripe_checkout_process_webhook(){
 
     if (!empty($checkout_session->data[0]->custom_fields)) {
         foreach ($checkout_session->data[0]->custom_fields as $custom_field) {
-            if ($custom_field->key == 'bfsmembershipnoifrenewal') {
-                $payment_data['bfs_membership'] = $custom_field->text->value;
-            }
+            $payment_data['custom_fields'][$custom_field->key] = [
+                'label' => $custom_field->label->custom,
+                'value' => $custom_field->text->value
+            ];
         }
     }
 
@@ -270,10 +271,6 @@ function wp_stripe_checkout_process_webhook(){
         $content .= '<strong>Email:</strong> '.$payment_data['customer_email'].'<br />'; 
     }
 
-    if(!empty($payment_data['bfs_membership'])){
-        $content .= '<strong>BFS Membership ID:</strong> '.$payment_data['bfs_membership'].'<br />';
-    }
-
     if(!empty($payment_data['stripe_customer_id'])){
         $content .= '<strong>Stripe Customer ID:</strong> '.$payment_data['stripe_customer_id'].'<br />'; 
     }
@@ -327,6 +324,16 @@ function wp_stripe_checkout_process_webhook(){
         }
         $content .= '<br />';
     }
+
+    if(!empty($payment_data['custom_fields'])){
+        $content .= '<strong>Custom Fields:</strong><br />';
+        foreach ($payment_data['custom_fields'] as $custom_field){
+            $content .= '<strong>' . $custom_field['label'] . ':</strong> ' .
+                $custom_field['value'].'<br />';
+        }
+        $content .= '<br />';
+    }
+
     $payment_data['order_id'] = '';
     $wp_stripe_checkout_order = array(
         'post_title' => 'order',

--- a/wp-stripe-checkout/wp-stripe-checkout-process-webhook.php
+++ b/wp-stripe-checkout/wp-stripe-checkout-process-webhook.php
@@ -88,6 +88,15 @@ function wp_stripe_checkout_process_webhook(){
         $product_price = $temp_product_price/100;
         $payment_data['price'] = number_format($product_price, 2, '.', '');
     }
+
+    if (!empty($checkout_session->data[0]->custom_fields)) {
+        foreach ($checkout_session->data[0]->custom_fields as $custom_field) {
+            if ($custom_field->key == 'bfsmembershipnoifrenewal') {
+                $payment_data['bfs_membership'] = $custom_field->text->value;
+            }
+        }
+    }
+
     $product_quantity = sanitize_text_field($checkout_session->data[0]->quantity);
     $payment_data['quantity'] = $product_quantity;
     $stripe_price_id = sanitize_text_field($checkout_session->data[0]->price->id);
@@ -260,6 +269,11 @@ function wp_stripe_checkout_process_webhook(){
     if(!empty($payment_data['customer_email'])){
         $content .= '<strong>Email:</strong> '.$payment_data['customer_email'].'<br />'; 
     }
+
+    if(!empty($payment_data['bfs_membership'])){
+        $content .= '<strong>BFS Membership ID:</strong> '.$payment_data['bfs_membership'].'<br />';
+    }
+
     if(!empty($payment_data['stripe_customer_id'])){
         $content .= '<strong>Stripe Customer ID:</strong> '.$payment_data['stripe_customer_id'].'<br />'; 
     }


### PR DESCRIPTION
Custom Fields in payment links are sent to the checkout session retrieval endpoint in the following format:

```
  "custom_fields": [
    {
      "id": "CUSTOM_FIELD_ID",
      "dropdown": null,
      "key": "CUSTOM_FIELD_KEY",
      "label": {
        "custom": "CUSTOM_FIELD_LABEL",
        "type": "custom"
      },
      "numeric": null,
      "optional": true,
      "text": {
        "default_value": null,
        "maximum_length": null,
        "minimum_length": null,
        "value": "CUSTOM_FIELD_VALUE"
      },
      "type": "text"
    }
  ],
```

So what this change does is loop through each custom field returned in the webhook, and ensures they're added to the post in the correct format.